### PR TITLE
GH-3 Add as a GlobalPlugin, rather than Scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,32 @@
 
 ### Config settings
 
+In your game config:
+
 ```
+import DragSelectPlugin from 'path-to';
+
+const config = {
+    ...
+    plugins: {
+        global: [
+            { key: 'DragSelectPlugin', plugin: DragSelectPlugin }
+        ]
+    },
+    ...
+```
+
+```
+this.dragSelect = this.plugins.start('DragSelectPlugin', 'dragSelect');
+this.dragSelect.setup(this, {
     camera: <MainGameSceneCamera>,
     childSelector: <Function>,
-    dragCameraBy: 2, // right-button 
+    dragCameraBy: 2, // right-button
     mouseClickToTrack: 1, // left-button
     outlineColor: 0x00ff00,
     outlineWidth: 2,
     onSelect: <Function>,
     rectBgColor: 0x33ff33,
     rectAlpha: 0.5,
+});
 ```

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -1,12 +1,17 @@
 import Phaser from 'phaser';
 
 import DemoScene from './scene/demo-scene';
+import DemoScene2 from './scene/demo-scene-2';
+import DragSelectPlugin from '../js/drag-select-plugin';
 
 const config = {
   type: Phaser.AUTO,
   width: 1600,
   height: 1000,
   parent: 'mycanvas',
+  plugins: {
+    global: [{ key: 'DragSelectPlugin', plugin: DragSelectPlugin }],
+  },
   physics: {
     default: 'arcade',
     arcade: {
@@ -14,7 +19,7 @@ const config = {
       gravity: { x: 0, y: 0 },
     },
   },
-  scene: [DemoScene],
+  scene: [DemoScene, DemoScene2],
 };
 
 const game = new Phaser.Game(config);

--- a/src/demo/scene/demo-scene-2.js
+++ b/src/demo/scene/demo-scene-2.js
@@ -1,0 +1,15 @@
+export default class DemoScene2 extends Phaser.Scene {
+  constructor() {
+    super('DemoScene2');
+  }
+
+  create() {
+    this.fpsText = this.add.text(500, 500, 'This is a scene with no drag-selection');
+    this.fpsText.setScrollFactor(0);
+
+    this.input.keyboard.on('keydown-R', () => {
+      this.scene.stop('DemoScene2');
+      this.scene.launch('DemoScene');
+    });
+  }
+}

--- a/src/demo/scene/demo-scene.js
+++ b/src/demo/scene/demo-scene.js
@@ -30,7 +30,7 @@ export default class DemoScene extends Scene {
       zoomOut: keyboard.addKey(KeyCodes.E),
       acceleration: 0.001,
       drag: 0.0005,
-      maxSpeed: 1.0
+      maxSpeed: 1.0,
     };
 
     this.myControls = new Phaser.Cameras.Controls.SmoothedKeyControl(controlConfig);
@@ -45,9 +45,9 @@ export default class DemoScene extends Scene {
     let spriteKey;
     let y;
 
-    for (x; x <= length; x+=1) {
+    for (x; x <= length; x += 1) {
       y = 1;
-      for (y; y <= length; y+=1) {
+      for (y; y <= length; y += 1) {
         // Every even numbered item will be set as "interactive"
         setAsInteractive = x % 2 === 0;
         spriteKey = setAsInteractive ? 'enabled-sprite' : 'disabled-sprite';
@@ -78,16 +78,23 @@ export default class DemoScene extends Scene {
     this.selectedSpritesText.setText(`${sprites.length} sprites selected`);
   }
 
-  preload() {
-    this.load.scenePlugin('DragSelectPlugin', DragSelectPlugin, 'dragSelect', 'dragSelect');
+  setDemoKeyEvents() {
+    this.input.keyboard.on('keydown-R', () => {
+      this.scene.stop('DemoScene');
+      this.scene.launch('DemoScene2');
+      this.plugins.stop('dragSelect');
+    });
+  }
 
+  preload() {
     this.load.image('disabled-sprite', 'src/assets/disabled-sprite-50x50.png');
     this.load.image('enabled-sprite', 'src/assets/enabled-sprite-50x50.png');
   }
 
   create() {
-    console.log('dragSelect', this.dragSelect);
-    this.dragSelect.init({
+    console.log('DemoScene scene', this);
+    this.dragSelect = this.plugins.start('DragSelectPlugin', 'dragSelect');
+    this.dragSelect.setup(this, {
       camera: this.cameras.main,
       // childSelector: () => true, // select everything! :-)
       // dragCameraBy: false, // disable drag camera
@@ -107,6 +114,7 @@ export default class DemoScene extends Scene {
 
     this.createCamera();
     this.createSprites();
+    this.setDemoKeyEvents();
   }
 
   update(time, delta) {

--- a/src/js/drag-select-plugin.js
+++ b/src/js/drag-select-plugin.js
@@ -1,156 +1,96 @@
 import Phaser from 'phaser';
 
-import InterfaceScene from './lib/interface-scene';
+import InterfaceScene, { SCENE_KEY } from './lib/interface-scene';
 import { EVENT_MAP } from './lib/constants';
 import PluginConfig from './lib/plugin-config';
 
-
 export default class DragSelectPlugin extends Phaser.Plugins.BasePlugin {
-  config;
   interfaceScene;
-
-  enabled = true;
+  scene;
+  // scenePlugin;
 
   constructor(pluginManager) {
     // console.log('constructor', scene);
     console.log('pluginManager', pluginManager);
     super(pluginManager);
-    this.active = true;
 
     // console.log('targetScene', scene);
     console.log('this', this);
+    console.log('this', this.setup);
   }
 
-  get scenePlugin() {
-    return this.pluginManager.scene;
-  }
-
-  init(config = {}) {
+  setup(scene, config = {}) {
     PluginConfig.setConfig(config);
 
+    this.scene = scene;
     this.createInterfaceScene();
     this.addEmitterEventCallbacks();
   }
 
+  get scenePlugin() {
+    return this.scene.scene;
+  }
+
   createInterfaceScene() {
     const scenePlugin = this.scenePlugin;
-
-    this.interfaceScene = new InterfaceScene(scenePlugin, this.config);
+    this.interfaceScene = scenePlugin.get(SCENE_KEY) || new InterfaceScene(scenePlugin, this.config);
+    scenePlugin.launch(SCENE_KEY);
   }
 
   addEmitterEventCallbacks() {
-    const eventEmitter = this.pluginManager.sys.events;
+    const eventEmitter = this.game.events;
+    // this.scenePlugin.events.on('shutdown', () => {
+    //   console.log('hi there')
+    // });
 
-    eventEmitter.on('update', this.update, this);
-
-    eventEmitter.on('start', this.start, this);
-
-    eventEmitter.on('preupdate', this.preUpdate, this);
-    eventEmitter.on('postupdate', this.postUpdate, this);
-
-    eventEmitter.on('pause', this.pause, this);
-    eventEmitter.on('resume', this.resume, this);
-
-    eventEmitter.on('sleep', this.sleep, this);
-    eventEmitter.on('wake', this.wake, this);
-
-    eventEmitter.on('shutdown', this.shutdown, this);
-    eventEmitter.on('destroy', this.destroy, this);
-
+    // eventEmitter.on('update', this.update, this);
+    //
+    //
+    // eventEmitter.on('pause', this.pause, this);
+    // eventEmitter.on('resume', this.resume, this);
+    //
+    // eventEmitter.on('shutdown', this.shutdown, this);
+    // eventEmitter.on('destroy', this.destroy, this);
+    //
     this.interfaceScene.sys.events.on(EVENT_MAP.ON_MOUSE_UP, this.onMouseUp);
   }
 
   onMouseUp = rectangle => {
-    const { manager } = this.scenePlugin;
-    const activeScenes = manager.getScenes();
+    const items = this.scene.children.getChildren().filter(child => {
+      const canSelectChild = PluginConfig.get('childSelector')(child);
 
-    const items = activeScenes.reduce((list, scene) => {
-      if (scene === this.interfaceScene) {
-        return list;
+      // If the child cannot be selected, or has not got any bounds
+      if (!canSelectChild || !child.getBounds) {
+        return;
       }
 
-      return list.concat(
-        scene.children.getChildren().filter(child => {
-          const canSelectChild = PluginConfig.get('childSelector')(child);
+      const camera = PluginConfig.get('camera');
+      const childBounds = child.getBounds();
+      const x = (childBounds.x - camera.worldView.x) * camera.zoom;
+      const y = (childBounds.y - camera.worldView.y) * camera.zoom;
+      const width = childBounds.width * camera.zoom;
+      const height = childBounds.height * camera.zoom;
+      const childRect = new Phaser.Geom.Rectangle(x, y, width, height);
 
-          // If the child cannot be selected, or has not got any bounds
-          if (!canSelectChild || !child.getBounds) {
-            return;
-          }
+      return Phaser.Geom.Rectangle.Overlaps(rectangle, childRect);
+    });
 
-          const camera = scene.cameras.main;
-          const childBounds = child.getBounds();
-          const x = (childBounds.x - camera.worldView.x) * camera.zoom;
-          const y = (childBounds.y - camera.worldView.y) * camera.zoom;
-          const width = childBounds.width * camera.zoom;
-          const height = childBounds.height * camera.zoom;
-          const childRect = new Phaser.Geom.Rectangle(x, y, width, height);
-
-          return Phaser.Geom.Rectangle.Overlaps(rectangle, childRect);
-        })
-      );
-    }, []);
-    console.log('activeScenes', activeScenes);
     console.log('items', items);
     PluginConfig.get('onSelect')(items);
   };
 
-  //  Called when the Plugin is booted by the PluginManager.
-  //  If you need to reference other systems in the Scene (like the Loader or DisplayList) then set-up those references now, not in the constructor.
-  boot() {
-    // this.createInterfaceScene();
-    // this.addEmitterEventCallbacks();
+  stop() {
+    super.stop();
+    this.scenePlugin.stop(SCENE_KEY);
   }
-
-  //  Called every Scene step - phase 1
-  preUpdate = (time, delta) => {};
-
-  //  Called every Scene step - phase 2
-  update(time, delta) {
-    if (!this.active) {
-      return;
-    }
-  }
-
-  //  Called every Scene step - phase 3
-  postUpdate(time, delta) {}
 
   //  Called when a Scene is paused. A paused scene doesn't have its Step run, but still renders.
   pause() {
     console.log('pause');
-    this.enabled = false;
   }
 
   //  Called when a Scene is resumed from a paused state.
   resume() {
     console.log('resume');
-    this.enabled = true;
   }
-
-  //  Called when a Scene is put to sleep. A sleeping scene doesn't update or render, but isn't destroyed or shutdown. preUpdate events still fire.
-  sleep() {
-    this.enabled = false;
-  }
-
-  //  Called when a Scene is woken from a sleeping state.
-  wake() {
-    // @TODO - is the game paused?
-    this.enabled = true;
-  }
-
-  //  Called when a Scene shuts down, it may then come back again later (which will invoke the 'start' event) but should be considered dormant.
-  shutdown() {}
-
-  //  Called when a Scene is destroyed by the Scene Manager. There is no coming back from a destroyed Scene, so clear up all resources here.
-  destroy() {
-    this.shutdown();
-    this.interfaceScene.destroy();
-    this.interfaceScene = undefined;
-  }
-
-  //  Custom method for this plugin
-  setDelay(delay) {}
-
-  //  Custom method for this plugin
-  reset() {}
 }

--- a/src/js/lib/interface-scene.js
+++ b/src/js/lib/interface-scene.js
@@ -6,6 +6,7 @@ export default class InterfaceScene extends Phaser.Scene {
   constructor(scenePlugin) {
     super({ key: SCENE_KEY, active: true });
 
+    console.log('scenePlugin', scenePlugin);
     scenePlugin.add(SCENE_KEY, this, true);
     scenePlugin.bringToTop(SCENE_KEY);
   }
@@ -13,10 +14,4 @@ export default class InterfaceScene extends Phaser.Scene {
   create() {
     this.mouseInterface = new MouseInterface(this);
   }
-
-  destroy() {
-    super.destroy(true);
-    this.mouseInterface.destroy(true);
-  }
-
 }

--- a/src/js/lib/mouse-interface.js
+++ b/src/js/lib/mouse-interface.js
@@ -149,17 +149,7 @@ export default class MouseInterface extends Phaser.GameObjects.Graphics {
   };
 
   destroy(fromScene) {
-    const { scene } = this;
     super.destroy(fromScene);
-
-    scene.input.off('pointerdown', this.onCameraDragPointerDown);
-    scene.input.off('pointerup', this.onCameraDragPointerUp);
-    scene.input.off('pointermove', this.onCameraDragPointerMove);
-
-    scene.input.off('pointerdown', this.onPointerDown);
-    scene.input.off('pointerup', this.onPointerUp);
-    scene.input.off('pointermove', this.onPointerMove);
-    scene.input.off('gameover', this.onGameOver);
   }
 
   preUpdate() {


### PR DESCRIPTION
- Changes the logic of the plugin to work as a `GlobalPlugin`, and one that's started / stopped as needed, instead of a Scene plugin
- The reason is because `ScenePlugin` gets added to each subsequent new scene - but because our Plugin itself creates a scene, that causes a weird feedback loop in the logic.
- Closes #3 