### PR TITLE
GH-4 Support shift/ctrl keys during mouse select

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ this.dragSelect.setup(this, {
     childSelector: <Function>,
     dragCameraBy: 2, // right-button
     mouseClickToTrack: 1, // left-button
+    mouseAmendSelectWith: 'shift',
+    mouseToggleSelectWith: 'ctrl',
     outlineColor: 0x00ff00,
     outlineWidth: 2,
     onSelect: <Function>,

--- a/src/js/lib/constants.js
+++ b/src/js/lib/constants.js
@@ -1,5 +1,0 @@
-export const PLUGIN_PREFIX = 'DRAG_SELECT';
-
-export const EVENT_MAP = {
-  ON_MOUSE_UP: `${PLUGIN_PREFIX}/ON_MOUSE_UP`,
-};

--- a/src/js/lib/interface-scene.js
+++ b/src/js/lib/interface-scene.js
@@ -3,10 +3,13 @@ import MouseInterface from './mouse-interface';
 export const SCENE_KEY = 'DragSelectPlugin:InterfaceScene';
 
 export default class InterfaceScene extends Phaser.Scene {
-  constructor(scenePlugin) {
+  dragPlugin;
+  mouseInterface;
+
+  constructor(scenePlugin, dragPlugin) {
     super({ key: SCENE_KEY, active: true });
 
-    console.log('scenePlugin', scenePlugin);
+    this.dragPlugin = dragPlugin;
     scenePlugin.add(SCENE_KEY, this, true);
     scenePlugin.bringToTop(SCENE_KEY);
   }

--- a/src/js/lib/mouse-interface.js
+++ b/src/js/lib/mouse-interface.js
@@ -1,4 +1,3 @@
-import { EVENT_MAP } from './constants';
 import PluginConfig, { MOUSE_BUTTONS } from './plugin-config';
 
 const PREVENT_DEFAULT = e => e.preventDefault();
@@ -15,9 +14,17 @@ export default class MouseInterface extends Phaser.GameObjects.Graphics {
   constructor(scene) {
     super(scene);
 
+    console.log('graphics', this);
     scene.add.existing(this);
     this.initialiseInputEvents();
     this.initialiseCameraDrag();
+  }
+
+  /**
+   * @return InterfaceScene
+   */
+  get dragPlugin() {
+    return this.scene.dragPlugin;
   }
 
   get isRightClickDisabled() {
@@ -101,8 +108,12 @@ export default class MouseInterface extends Phaser.GameObjects.Graphics {
     this.isMouseDown = true;
   };
 
-  onPointerUp = pointer => {
+  onPointerUp = ({ event }) => {
     const { start, end } = this;
+    const amendKey = PluginConfig.get('mouseAmendSelectWith');
+    const toggleKey = PluginConfig.get('mouseToggleSelectWith');
+    const isAmendActive = event[`${amendKey}Key`];
+    const isToggleActive = event[`${toggleKey}Key`];
 
     this.isDragging = false;
     this.isMouseDown = false;
@@ -125,7 +136,7 @@ export default class MouseInterface extends Phaser.GameObjects.Graphics {
     const height = maxY - minY;
     const rectangle = new Phaser.Geom.Rectangle(minX, minY, width, height);
 
-    this.scene.sys.events.emit(EVENT_MAP.ON_MOUSE_UP, rectangle);
+    this.dragPlugin.onMouseUp(rectangle, isAmendActive, isToggleActive);
   };
 
   enableRightClick(enable = true) {

--- a/src/js/lib/plugin-config.js
+++ b/src/js/lib/plugin-config.js
@@ -12,18 +12,26 @@ export const MOUSE_BUTTONS = {
   RIGHT: 2,
   MIDDLE: 4,
   FOURTH_BUTTON: 8,
-  FIFTH_BUTTON: 16
+  FIFTH_BUTTON: 16,
 };
 
 const MOUSE_BUTTONS_VALUES = Object.values(MOUSE_BUTTONS);
 
 export const IS_INTERACTIVE_CHILD = child => child.input?.enabled;
 
+export const AMEND_SELECT_OPTIONS = {
+  ALT: 'alt',
+  CTRL: 'ctrl',
+  SHIFT: 'shift',
+};
+
 export const PLUGIN_DEFAULT_CONFIG = {
   camera: null,
   childSelector: IS_INTERACTIVE_CHILD,
   dragCameraBy: MOUSE_BUTTONS.RIGHT,
   mouseClickToTrack: MOUSE_BUTTONS.LEFT,
+  mouseAmendSelectWith: AMEND_SELECT_OPTIONS.SHIFT,
+  mouseToggleSelectWith: AMEND_SELECT_OPTIONS.CTRL,
   outlineColor: 0x00ff00,
   outlineWidth: 2,
   onSelect: NOOP,
@@ -37,7 +45,7 @@ class PluginConfig {
   setConfig(data = {}) {
     this.data = {
       ...PLUGIN_DEFAULT_CONFIG,
-      ...data
+      ...data,
     };
   }
 


### PR DESCRIPTION
- Supposes the ability to use `Shift` and `Ctrl` keys during mouse selection.
- Allows those keys to be configurable as well.
- Closes #4 