### PR TITLE
GH-10 Add "preview" callback for mouseMove

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ this.dragSelect = this.plugins.start('DragSelectPlugin', 'dragSelect');
 this.dragSelect.setup(this, {
     camera: <MainGameSceneCamera>,
     childSelector: <Function>,
-    dragCameraBy: 2, // right-button
-    mouseClickToTrack: 1, // left-button
+    dragCameraBy: 2,        // right-button
+    mouseClickToTrack: 1,   // left-button
     mouseAmendSelectWith: 'shift',
     mouseToggleSelectWith: 'ctrl',
     outlineColor: 0x00ff00,
     outlineWidth: 2,
+    onPreview: <Function>,
     onSelect: <Function>,
     rectBgColor: 0x33ff33,
     rectAlpha: 0.5,

--- a/src/demo/scene/demo-scene.js
+++ b/src/demo/scene/demo-scene.js
@@ -6,6 +6,8 @@ import { forEach } from 'src/js/util';
 const { KeyCodes } = Phaser.Input.Keyboard;
 
 const ROTATE_BY = 0.025;
+const TINT_PREVIEW = 0x00ff00;
+const TINT_SELECTION = 0xff00ff;
 
 export default class DemoScene extends Scene {
   dragSelect;
@@ -63,12 +65,29 @@ export default class DemoScene extends Scene {
     }
   }
 
+  onPreview = sprites => {
+    forEach(this.children.getChildren(), sprite => {
+      // Ignore if already selected...
+      if (sprite.tintTopLeft === TINT_SELECTION) {
+        return;
+      }
+
+      // If one of the sprites under the selection, set tint
+      if (sprites.includes(sprite)) {
+        return sprite.setTint(TINT_PREVIEW);
+      }
+
+      // Otherwise, clear it.
+      sprite.setTint(0xffffff);
+    });
+
+    // sprites.forEach(sprite => sprite.setTint(0x00ff00));
+  };
+
   onSelect = sprites => {
     console.warn('sprites', sprites);
 
-    this.children.getChildren().forEach(obj => {
-      obj.setTint(0xffffff);
-    });
+    this.children.getChildren().forEach(s => s.setTint(0xffffff));
 
     sprites.forEach(sprite => sprite.setTint(0xff00ff));
     this.setSelectedSpritesText(sprites);
@@ -98,6 +117,7 @@ export default class DemoScene extends Scene {
       camera: this.cameras.main,
       // childSelector: () => true, // select everything! :-)
       // dragCameraBy: false, // disable drag camera
+      onPreview: this.onPreview,
       onSelect: this.onSelect,
       outlineColor: 0x00ff00,
       outlineWidth: 2,

--- a/src/js/lib/plugin-config.js
+++ b/src/js/lib/plugin-config.js
@@ -34,6 +34,7 @@ export const PLUGIN_DEFAULT_CONFIG = {
   mouseToggleSelectWith: AMEND_SELECT_OPTIONS.CTRL,
   outlineColor: 0x00ff00,
   outlineWidth: 2,
+  onPreview: NOOP,
   onSelect: NOOP,
   rectBgColor: 0x33ff33,
   rectAlpha: 0.5,


### PR DESCRIPTION
- Adds an `onPreview` callback so that we can show selection previews of Sprites, if desired.
- So while dragging the mouse, the `onPreview` config setting is invoked, passing all the valid Objects that fall under the selection
- Closes #10 